### PR TITLE
Close pipeline-async channel to continue send-chan messaging

### DIFF
--- a/src/qb/core.clj
+++ b/src/qb/core.clj
@@ -36,7 +36,8 @@
         s-ack (send! sender dest msg)
         s-ack-mult (async/mult s-ack)]
     (if ack (async/tap s-ack-mult ack))
-    (async/tap s-ack-mult done)))
+    (async/tap s-ack-mult done)
+    (async/close! done)))
 
 (defn send-chan
   "Wrap a sender with a channel of messages to send.


### PR DESCRIPTION
There's a subtle bug here with the use of `pipeline-async`. Closing the `done` channel after copying the message allows `pipeline-async` to process the next `in` message.

I ran into this issue when debugging pitstop (Pitstop would stop processing messages after ~100 emits)

cc @yanatan16 
