### PR TITLE
fix send-chan

### DIFF
--- a/src/qb/util.clj
+++ b/src/qb/util.clj
@@ -17,6 +17,14 @@
   (if (instance? ManyToManyChannel ackc)
     (go (>! ackc err) (close! ackc))))
 
+;; pipes an ack chan to possibly many other ack chans
+
+(defn pipe-ack [from & tos]
+  (go-loop []
+    (let [v (<! from)]
+      (if v (do (doseq [to tos] (>! to v)) (recur))
+            (doseq [to tos] (close! to))))))
+
 (defn wrap-ack-chan-xf
   "Create an xform that can be used to map a channel of messages
   to a channel of {:ack ack-chan :msg msg}.


### PR DESCRIPTION
adds `pipe-ack` to act like `mult`/`tap` but for actions that may have already happened. See #1
